### PR TITLE
ADD: helper.py to auto replace appid and email

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+""" uploader helper for KindleEar
+It will modify appid and some item for you automatically.
+configure file 'custom.txt' format (encoding must be ascii):
+application: youid
+email: youemail
+timezone: 8
+If it not exist, this script will create it automatically.
+"""
+import os, re, codecs
+__Author__ = 'cdhigh'
+__Version__ = '1.2'
+__Date__ = '2014-04-28'
+
+CUSTOM_FILE = 'custom.txt'
+KE_DIR = 'kindleear'
+PAT_APP = r"^application:\s*([\w]+)"
+PAT_EMAIL = r"^SRC_EMAIL\s*=\s*[\"\']([\w@\.-]+)[\"\'](.*)"
+PAT_DOMAIN = r"^DOMAIN\s*=\s*[\"\']([\w:/\.-]+)[\"\'](.*)"
+PAT_TZ = r"^TIMEZONE\s*=\s*?(-{0,1}\d+)(.*)"
+
+def Main():
+    ke_dir = os.path.dirname(__file__)
+
+    custom_file = os.path.join(os.path.dirname(__file__), CUSTOM_FILE)
+    app_yaml = os.path.join(ke_dir, 'app.yaml')
+    work_yaml = os.path.join(ke_dir, 'module-worker.yaml')
+    cfg_file = os.path.join(ke_dir, 'config.py')
+    
+    slapp = []
+    if os.path.exists(app_yaml):
+        with open(app_yaml, 'r') as fapp:
+            slapp = fapp.read().split('\n')
+    if not slapp:
+        print("Not exist 'app.yaml' or it's invalid, please download KindleEar again.")
+        return 1
+        
+    slcfg = []
+    if os.path.exists(cfg_file):
+        with codecs.open(cfg_file, 'r', 'utf-8') as fcfg:
+            slcfg = fcfg.read().split('\n')
+    if not slcfg:
+        print("Not exist 'config.py' or it's invalid, please download KindleEar again.")
+        return 1
+        
+    slwork = []
+    if os.path.exists(work_yaml):
+        with open(work_yaml, 'r') as fwork:
+            slwork = fwork.read().split('\n')
+    
+    #init some parameter
+    app = email = timezone = ''
+    mt1 = re.match(PAT_APP, slapp[0])
+    mt2 = re.match(PAT_APP, slwork[0]) if slwork else mt1
+    if mt1 and mt2 and mt1.group(1) == mt2.group(1):
+        app = mt1.group(1)
+    for index, line in enumerate(slcfg):
+        mt = re.match(PAT_EMAIL, line)
+        if mt:
+            email = mt.group(1)
+            continue
+        mt = re.match(PAT_DOMAIN, line)
+        if mt:
+            domain = mt.group(1)
+            continue
+        mt = re.match(PAT_TZ, line)
+        if mt:
+            timezone = mt.group(1)
+            continue
+            
+    slcustom = []
+    needinput = True
+    if os.path.exists(custom_file):
+        with open(custom_file, 'r') as fcustom:
+            slcustom = fcustom.read().split('\n')
+        for line in slcustom:
+            if line.lower().startswith('application:'):
+                app = line[len('application:'):].strip()
+            elif line.lower().startswith('email:'):
+                email = line[len('email:'):].strip()
+            elif line.lower().startswith('timezone:'):
+                timezone = line[len('timezone:'):].strip()
+    
+    ret = raw_input('Your custom info :\n\t  app id : %s\n\t   email : %s\n\ttimezone : %s\nCorrect? (y/n) : '%(app,email,timezone))
+    if ret in ('y', 'Y'):
+        needinput = False
+    
+    while 1:
+        if needinput or not all((app, email, timezone)):
+            new_app = raw_input('Input app id (%s): '%app)
+            new_email = raw_input('Input your gmail (%s): '%email)
+            new_timezone = raw_input('Input your timezone (%s): '%timezone)
+            app = new_app if new_app else app
+            email = new_email if new_email else email
+            timezone = new_timezone if new_timezone else timezone
+            with open(custom_file, 'w') as fcustom:
+                fcustom.write('application: %s\n' % app)
+                fcustom.write('email: %s\n' % email)
+                fcustom.write('timezone: %s' % timezone)
+                
+        if all((app, email, timezone)):
+            break
+        elif not app:
+            print('app id is empty, please input it again.')
+        elif not email:
+            print('email is empty, please input it again.')
+        elif not timezone:
+            print('timezone is empty, please input it again.')
+        
+    #Check and modify app.yaml
+    mt = re.match(PAT_APP, slapp[0])
+    if mt:
+        if mt.group(1) != app:
+            slapp[0] = 'application: ' + app
+            with open(app_yaml, 'w') as fapp:
+                fapp.write('\n'.join(slapp))
+    else:
+        print('app.yaml seems invalid, please download KindleEar again.')
+        return 1
+    
+    #Check and modify module-work.yaml
+    if slwork:
+        mt = re.match(PAT_APP, slwork[0])
+        if mt:
+            if mt.group(1) != app:
+                slwork[0] = 'application: ' + app
+                with open(work_yaml, 'w') as fwork:
+                    fwork.write('\n'.join(slwork))
+        else:
+            print('module-work.yaml seems invalid, please download KindleEar again.')
+            return 1
+    
+    #Check and modify config.py
+    cfg_changed = False
+    for index, line in enumerate(slcfg):
+        mt = re.match(PAT_EMAIL, line)
+        if mt:
+            if mt.group(1) != email:
+                slcfg[index] = 'SRC_EMAIL = "%s"'%email + mt.group(2)
+                cfg_changed = True
+            continue
+        mt = re.match(PAT_DOMAIN, line)
+        if mt:
+            domain = mt.group(1)
+            if domain.endswith('appspot.com') and domain not in (
+                'http://%s.appspot.com'%app, 'https://%s.appspot.com'%app):
+                slcfg[index] = 'DOMAIN = "https://%s.appspot.com"'%app + mt.group(2)
+                cfg_changed = True
+            continue
+        mt = re.match(PAT_TZ, line)
+        if mt:
+            if mt.group(1) != timezone:
+                slcfg[index] = 'TIMEZONE = %s'%timezone + mt.group(2)
+                cfg_changed = True
+            continue
+    if cfg_changed:
+        with codecs.open(cfg_file, 'w', 'utf-8') as fcfg:
+            fcfg.write('\n'.join(slcfg))
+            
+    return 0
+    
+if __name__ == '__main__':
+    print('\nKindleEar uploader v%s (%s) by %s\n' % (__Version__,__Date__,__Author__))
+    ret = Main()
+    if ret:
+        import sys
+        sys.exit(ret)
+        

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-﻿Readme of english version refers to Readme_EN.txt
+Readme of english version refers to Readme_EN.txt
 
 #简介
 这是一个运行在Google App Engine(GAE)上的Kindle个人推送服务器，生成排版精美的杂志模式MOBI格式自动每天推送至您的kindle，
@@ -20,11 +20,16 @@
 2. 下载GAE SDK。 <https://developers.google.com/appengine/downloads?hl=zh-CN>
 3. 安装Python 2.7 如果已经安装了，跳过此步骤
 4. 下载本应用的所有文件，放到一个特定的目录。
-5. 修改app.yaml/module-worker.yaml的第一行：将kindleear修改为你申请的application名字
-6. 修改config.py中的这几个变量
-   SRC_EMAIL ：你申请GAE账号时的GMAIL邮箱
-   DOMAIN ：你申请的应用的域名
-7. 转到GAE SDK安装目录（默认为：C:\Program Files\Google\google_appengine）
+5. 在以下三个文件中修改：applicationID 和 email（或者运行 [`helper.py`](helper.py) 脚本自动修改）
+
+             文件            |  待修改内容  | 说明                     |
+   -------------------------|------------|--------------------------|
+   app.yaml 的第一行         | kindleear	 | 修改为你申请的applicationID |
+   module-worker.yaml的第一行| kindleear  | 修改为你申请的applicationID |
+   config.py               | SRC_EMAIL  | 你申请GAE账号时的GMAIL邮箱   |
+                           | DOMAIN     | 你申请的应用的域名           |
+
+6. 转到GAE SDK安装目录（默认为：C:\Program Files\Google\google_appengine）
    执行CMD命令：
    `c:\python27\python.exe appcfg.py update kindleear目录\app.yaml kindleear目录\module-worker.yaml`
    <br />比如：<br />
@@ -33,9 +38,10 @@
    app_name.appspot.com (app_name是你申请的application名字)
    比如作者的网站域名为：kindleear.appspot.com
    开始您的个人推送服务了。
+
    注：初始用户为admin，密码为admin，建议登陆后及时修改密码。
-8. 更详细一点的说明请参照FAQ。
-9. 或者如果你不想安装python和GAE SDK，可以下载此uploader，将kindleear下载后不需要修改什么，
+7. 更详细一点的说明请参照[FAQ](static/faq.html)。(部署失败，部署后"internal server error"等都有解释)
+8. 或者如果你不想安装python和GAE SDK，可以下载此uploader，将kindleear下载后不需要修改什么，
    解压后将目录改名为kindleear，放到uploader目录下，
    双击uploader.bat即可上传。
    <https://drive.google.com/folderview?id=0ByRickMo9V_XNlJITzhYM3JOYW8&usp=sharing>


### PR DESCRIPTION
发现很多人都在问部署失败或者 “internal server error” 问题，这两个问题我都遇到过，觉得的比较普遍，应该解决下。
1.不少部署失败是因为部署前的修改漏掉了一些地方，我改了readme，以突出要改的四个地方。并从你的uploader中copy了helper.py 改了下（不需要判断是否有KindleEar目录，而是直接在当前目录检测那几个文件），可以在当前目录自动修改appid， email等。 
2.不少人遇到“internal server error”的问题，我也在readme中加上了一行说明让去Faq去找，而不是老有人提Issue。
