### PR TITLE
更改漫画的更新单位为话

### DIFF
--- a/books/comic/cartoonmadbase.py
+++ b/books/comic/cartoonmadbase.py
@@ -71,7 +71,7 @@ class CartoonMadBaseBook(BaseComicBook):
     def UpdateLastDelivered(self, title, num):
         userName = self.UserName()
         dbItem = LastDelivered.all().filter('username = ', userName).filter('bookname = ', title).get()
-        self.last_delivered_volume = u' 第%d卷' % num
+        self.last_delivered_volume = u' 第%d话' % num
         if dbItem:
             dbItem.num = num
             dbItem.record = self.last_delivered_volume
@@ -130,4 +130,4 @@ class CartoonMadBaseBook(BaseComicBook):
                     break
                     
         return urls
-        
+


### PR DESCRIPTION
一般周刊的漫画以"话"为单位，1"卷"包括若干"话"。
你不看漫画估计不太清楚，我认为用"话"比较好。
顺便删除一个tailing whitespace.