### PR TITLE
缩放漫画中过大的图片

### DIFF
--- a/apps/BaseHandler.py
+++ b/apps/BaseHandler.py
@@ -97,7 +97,7 @@ class BaseHandler:
         for i in range(SENDMAIL_RETRY_CNT+1):
             try:
                 mail.send_mail(SRC_EMAIL, to, "KindleEar %s" % lctime, "Deliver from KindleEar",
-                    attachments=[(filename.encode('gbk') if GBK_FILENAME else filename, attachment),])
+                    attachments=[(filename, attachment),])
             except OverQuotaError as e:
                 default_log.warn('overquota when sendmail to %s:%s' % (to, str(e)))
                 self.deliverlog(name, str(to), title, len(attachment), tz=tz, status='over quota')

--- a/apps/BaseHandler.py
+++ b/apps/BaseHandler.py
@@ -97,7 +97,7 @@ class BaseHandler:
         for i in range(SENDMAIL_RETRY_CNT+1):
             try:
                 mail.send_mail(SRC_EMAIL, to, "KindleEar %s" % lctime, "Deliver from KindleEar",
-                    attachments=[(filename, attachment),])
+                    attachments=[(filename.encode('gbk') if GBK_FILENAME else filename, attachment),])
             except OverQuotaError as e:
                 default_log.warn('overquota when sendmail to %s:%s' % (to, str(e)))
                 self.deliverlog(name, str(to), title, len(attachment), tz=tz, status='over quota')

--- a/apps/Work/Worker.py
+++ b/apps/Work/Worker.py
@@ -335,7 +335,7 @@ class Worker(BaseHandler):
         
         #新生成的图片再整体缩小到设定大小
         rw,rh = opts.reduce_image_to
-        ratio = min(float(rw)/float(new_size[0]), float(rh)/float(new_size[0]))
+        ratio = min(float(rw)/float(new_size[0]), float(rh)/float(new_size[1]))
         imgnew = imgnew.resize((int(new_size[0]*ratio), int(new_size[1]*ratio)))
         data = StringIO.StringIO()
         imgnew.save(data, 'JPEG')

--- a/apps/Work/Worker.py
+++ b/apps/Work/Worker.py
@@ -198,11 +198,11 @@ class Worker(BaseHandler):
                         itemcnt += 1
                         #找到相应的Feed实例并更新lastArticle属性
                         if (not bk.builtin) and sec_or_media != lastSec:
-                            fd = feeds.filter('title = ',sec_or_media).get()
+                            fd = Feed.all().filter('title = ',sec_or_media).get()
                             if fd:
                                 fd.lastArticle = title#这里的title是文章标题，Feed里的title其实是这里的section name
                                 fd.put()
-                                lastSec = sec_or_media
+                            lastSec = sec_or_media
                         
             except Exception as e:
                 excFileName, excFuncName, excLineNo = get_exc_location()

--- a/apps/Work/Worker.py
+++ b/apps/Work/Worker.py
@@ -179,7 +179,6 @@ class Worker(BaseHandler):
             #    img的thumbail仅当其为article的第一个img为True
             try: #书的质量可能不一，一本书的异常不能影响其他书籍的推送
                 lastSec = ''
-                seccnt = 0
                 for sec_or_media, url, title, content, brief, thumbnail in book.Items():
                     if not sec_or_media or not title or not content:
                         continue
@@ -197,12 +196,13 @@ class Worker(BaseHandler):
                         sections.setdefault(sec_or_media, [])
                         sections[sec_or_media].append((title, brief, thumbnail, content))
                         itemcnt += 1
-                        if (not bk.builtin) and sec_or_media != lastSec:#找到相应的Feed实体并更新lastArticle属性
-                            if feeds[seccnt].title ==  sec_or_media:
-                                feeds[seccnt].lastArticle = title
-                                feeds[seccnt].put()
+                        #找到相应的Feed实例并更新lastArticle属性
+                        if (not bk.builtin) and sec_or_media != lastSec:
+                            fd = feeds.filter('title = ',sec_or_media).get()
+                            if fd:
+                                fd.lastArticle = title#这里的title是文章标题，Feed里的title其实是这里的section name
+                                fd.put()
                                 lastSec = sec_or_media
-                            seccnt += 1
                         
             except Exception as e:
                 excFileName, excFuncName, excLineNo = get_exc_location()

--- a/apps/dbModels.py
+++ b/apps/dbModels.py
@@ -109,6 +109,7 @@ class Feed(db.Model):
     url = db.StringProperty()
     isfulltext = db.BooleanProperty()
     time = db.DateTimeProperty() #源被加入的时间，用于排序
+    lastArticle = db.StringProperty() #最近一次抓取时的文章名，用于避免重复抓取
 
 #书籍的推送历史记录
 class DeliverLog(db.Model):

--- a/books/base.py
+++ b/books/base.py
@@ -1374,6 +1374,7 @@ class BaseComicBook(BaseFeedBook):
                 imgMime = r"image/" + imgType
                 fnImg = "img%d.%s" % (self.imgindex, 'jpg' if imgType=='jpeg' else imgType)
                 imgFilenameList.append(fnImg)
+                content = self.process_image(content)
                 yield (imgMime, url, fnImg, content, None, None)
             else: #不是图片，有可能是包含图片的网页，抽取里面的图片
                 content = self.AutoDecodeContent(content, decoder, self.page_encoding, opener.realurl, result.headers)
@@ -1419,6 +1420,7 @@ class BaseComicBook(BaseFeedBook):
                         imgMime = r"image/" + imgType
                         fnImg = "img%d.%s" % (self.imgindex, 'jpg' if imgType=='jpeg' else imgType)
                         imgFilenameList.append(fnImg)
+                        imgContent = self.process_image(imgContent)
                         yield (imgMime, imgUrl, fnImg, imgContent, None, None)
                 else: #多个图片，要分析哪些才是漫画
                     isComics = [True for n in range(len(imgContentList))]
@@ -1446,6 +1448,7 @@ class BaseComicBook(BaseFeedBook):
                             imgMime = r"image/" + imgType
                             fnImg = "img%d.%s" % (self.imgindex, 'jpg' if imgType=='jpeg' else imgType)
                             imgFilenameList.append(fnImg)
+                            imgContent = self.process_image(imgContent)
                             yield (imgMime, imgUrl, fnImg, imgContent, None, None)
             
             #每个图片当做一篇文章，否则全屏模式下图片会挤到同一页

--- a/books/base.py
+++ b/books/base.py
@@ -259,6 +259,7 @@ class BaseFeedBook:
         for feed in self.feeds:
             section, url = feed[0], feed[1]
             isfulltext = feed[2] if len(feed) > 2 else False
+            lastarticle = feed[3] if len(feed) > 3 else ''
             timeout = self.timeout+10 if isfulltext else self.timeout
             opener = URLOpener(self.host, timeout=timeout, headers=self.extra_header)
             result = opener.open(url)
@@ -290,8 +291,10 @@ class BaseFeedBook:
                             self.log.info("Skip old article(%s): %s" % (updated.strftime('%Y-%m-%d %H:%M:%S'), e.link))
                             continue
                     
-                    title = e.title if hasattr(e, 'title') else 'Untitled'
-                    
+                    strUntitled = 'Untitled'
+                    title = e.title if hasattr(e, 'title') else strUntitled
+                    if title == lastarticle and title != strUntitled and DONOTREPEAT:#如果遇到已经推送过的文章，则跳出循环
+                        break
                     #支持HTTPS
                     if hasattr(e, 'link'):
                         if url.startswith('https://'):

--- a/config.py
+++ b/config.py
@@ -21,6 +21,8 @@ CONNECTION_TIMEOUT = 60
 
 # True to translate filename in chinese to pinyin
 PINYIN_FILENAME = False
+#If True, use 'GBK' to encode the final filename of books (for Windows)
+GBK_FILENAME = True
 
 #If set to True, encoding detected by chardet module will be used for each article
 #otherwise encoding in http response header or meta of html is used in proprity.

--- a/config.py
+++ b/config.py
@@ -21,8 +21,6 @@ CONNECTION_TIMEOUT = 60
 
 # True to translate filename in chinese to pinyin
 PINYIN_FILENAME = False
-#If True, use 'GBK' to encode the final filename of books (for Windows)
-GBK_FILENAME = True
 
 #If set to True, encoding detected by chardet module will be used for each article
 #otherwise encoding in http response header or meta of html is used in proprity.

--- a/config.py
+++ b/config.py
@@ -36,6 +36,9 @@ TRUST_ENCODING_IN_HEADER_OR_META = True
 GENERATE_TOC_DESC = True
 TOC_DESC_WORD_LIMIT = 500
 
+#Do not send articles that has been sent
+DONOTREPEAT = True
+
 #-------------------add by rexdf-----------
 #title for table of contents
 TABLE_OF_CONTENTS = u'Table Of Contents'

--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ GENERATE_TOC_DESC = True
 TOC_DESC_WORD_LIMIT = 500
 
 #Do not send articles that has been sent
-DONOTREPEAT = True
+DONOTREPEAT = False
 
 #-------------------add by rexdf-----------
 #title for table of contents

--- a/lib/calibre/customize/profiles.py
+++ b/lib/calibre/customize/profiles.py
@@ -172,6 +172,7 @@ class KindleInput(InputProfile):
     # Screen size is a best guess
     screen_size               = (525, 640)
     dpi                       = 168.451
+    comic_screen_size         = (600, 800)#added by cover-me
     fbase                     = 16
     fsizes                    = [12, 12, 14, 16, 18, 20, 22, 24]
 
@@ -675,6 +676,7 @@ class KindleOutput(OutputProfile):
     # Screen size is a best guess
     screen_size               = (525, 640)
     dpi                       = 168.451
+    comic_screen_size         = (600, 800)#added by cover-me
     fbase                     = 16
     fsizes                    = [12, 12, 14, 16, 18, 20, 22, 24]
     supports_mobi_indexing = True

--- a/lib/calibre/utils/img.py
+++ b/lib/calibre/utils/img.py
@@ -60,7 +60,7 @@ def rescale_image(data, maxsizeb=4000000, dimen=None,
         img.save(data, fmt)
     elif width > reducewidth or height > reduceheight:
         ratio = min(float(reducewidth)/float(width), float(reduceheight)/float(height))
-        img = img.resize((int(width*ratio), int(height*ratio)))
+        img = img.resize((int(width*ratio), int(height*ratio)),Image.ANTIALIAS)
         if png2jpg and fmt == 'PNG':
             fmt = 'JPEG'
         data = StringIO()


### PR DESCRIPTION
1. 缩放漫画中过大的图片。（对于Kindle 4，Calibre库中设定的分辨率偏小，不知道他这样做是什么道理。这会导致图片缩放过头，可以在config.py里手动设置 REDUCE_IMAGE_TO 参数来覆盖设置）
2. 在config.py中增加gbk编码文件名的选项（GBK_FILENAME），修正Windows系统下文件乱码的问题。
3. 对于自定义RSS，通过读取上一回推送过的最新文章记录来避免重复推送。利用中的config.py DONOTREPEAT变量来开关该功能。由于是通过文章名来判断是否已推送，需要手动在设置页面中把“题目来源”设为FEED。另外要避免RSS取的名字重复。
4. 图片处理方面的一些改动。