### PR TITLE
修改腾讯漫画逻辑，添加manhuagui的重试处理

### DIFF
--- a/books/base.py
+++ b/books/base.py
@@ -1439,8 +1439,15 @@ class BaseComicBook(BaseFeedBook):
                 continue
 
             content = self.adjustImgContent(content);
+            if content == None:
+                self.log.warn("Image adjust error, try again: {}".format(url.encode('utf-8')))
+                content = self.adjustImgContent(content);
+                if content == None:
+                    self.log.warn("Image adjust error: {}".format(url.encode('utf-8')))
+                    continue
+
             imgFilenameList = []
-            
+
             #先判断是否是图片
             imgType = imghdr.what(None, content)
             if imgType:

--- a/books/comic/manhuaguibase.py
+++ b/books/comic/manhuaguibase.py
@@ -25,11 +25,13 @@ class ManHuaGuiBaseBook(BaseComicBook):
     #获取漫画图片内容
     def adjustImgContent(self, content):
         #强制转换成JPEG
-        img = images.Image(content)
-        img.resize(width=(img.width-1), height=(img.height-1))
-        content = img.execute_transforms(output_encoding=images.JPEG)
-
-        return content
+        try:
+            img = images.Image(content)
+            img.resize(width=(img.width-1), height=(img.height-1))
+            content = img.execute_transforms(output_encoding=images.JPEG)
+            return content
+        except:
+            return None
 
     #获取图片信息
     def get_node_online(self, input_str):

--- a/books/comic/tencentbase.py
+++ b/books/comic/tencentbase.py
@@ -95,7 +95,7 @@ class TencentBaseBook(BaseComicBook):
                 base64data = filter_result[0].split("cGljdHVyZSI6")[1]
                 self.log.warn('found flag string: %s'%"cGljdHVyZSI6")
             elif "aWN0dXJlIjpb" in filter_result[0]:
-                base64data = filter_result[0].split("aWN0dXJlIjpb")[1]
+                base64data = filter_result[0].split("aWN0dXJl")[1]
                 self.log.warn('found flag string: %s'%"aWN0dXJlIjpb")
             else:
                 self.log.warn('can not found flag string in data: %s'%filter_result[0])

--- a/books/comic/tencentbase.py
+++ b/books/comic/tencentbase.py
@@ -34,7 +34,7 @@ class TencentBaseBook(BaseComicBook):
             self.log.warn('can not get comic id: %s' % url)
             return chapterList
 
-        url = 'http://m.ac.qq.com/comic/chapterList/id/{}'.format(comic_id)
+        url = 'https://m.ac.qq.com/comic/chapterList/id/{}'.format(comic_id)
         result = opener.open(url)
         if result.status_code != 200 or not result.content:
             self.log.warn('fetch comic page failed: %s' % url)
@@ -58,7 +58,8 @@ class TencentBaseBook(BaseComicBook):
 
         for item in reverse_list.find_all('a'):
             # <a class="chapter-link lock" data-cid="447" data-seq="360" href="/chapter/index/id/531490/cid/447">360</a>
-            href = 'http://m.ac.qq.com' + item.get('href')
+            # https://m.ac.qq.com/chapter/index/id/511915/cid/1
+            href = 'https://m.ac.qq.com' + item.get('href')
             isVip = "lock" in item.get('class')
             if isVip == True:
                 self.log.info("Chapter {} is Vip, waiting for free.".format(href))
@@ -82,13 +83,37 @@ class TencentBaseBook(BaseComicBook):
         content = result.content
         cid_page = self.AutoDecodeContent(content, decoder, self.page_encoding, opener.realurl, result.headers)
         filter_result = re.findall(r"data\s*:\s*'(.+?)'", cid_page)
+        # "picture": [{},...{}]}
         if len(filter_result) != 0:
-            base64data = filter_result[0][1:]
-            img_detail_json = json.loads(base64.decodestring(base64data))
-            for img_url in img_detail_json.get('picture', []):
-                if ( 'url' in img_url ):
-                    imgList.append(img_url['url'])
-                else:
-                    self.log.warn('no url in img_url:%s' % img_url)
+            # "picture" > InBpY3R1cmUi
+            # picture": > cGljdHVyZSI6
+            # icture":[ > aWN0dXJlIjpb
+            if "InBpY3R1cmUi" in filter_result[0]:
+                base64data = filter_result[0].split("InBpY3R1cmUi")[1]
+                self.log.warn('found flag string: %s'%"InBpY3R1cmUi")
+            elif "cGljdHVyZSI6" in filter_result[0]:
+                base64data = filter_result[0].split("cGljdHVyZSI6")[1]
+                self.log.warn('found flag string: %s'%"cGljdHVyZSI6")
+            elif "aWN0dXJlIjpb" in filter_result[0]:
+                base64data = filter_result[0].split("aWN0dXJlIjpb")[1]
+                self.log.warn('found flag string: %s'%"aWN0dXJlIjpb")
+            else:
+                self.log.warn('can not found flag string in data: %s'%filter_result[0])
+                return imgList
+            decodeData = base64.decodestring(base64data)
+            startIndex = decodeData.find('[')
+            endIndex = decodeData.find(']')
+
+            if startIndex > -1 and endIndex > -1:
+                img_detail_json = json.loads(decodeData[startIndex:endIndex+1])
+                for img_url in img_detail_json:
+                    if ( 'url' in img_url ):
+                        imgList.append(img_url['url'])
+                    else:
+                        self.log.warn('no url in img_url:%s' % img_url)
+            else:
+                self.log.warn('can not found [] in decodeData:%s' % decodeData)
+        else:
+            self.log.warn('can not fount filter_result with data: .')
 
         return imgList


### PR DESCRIPTION
1 腾讯漫画的网页针对base64的解码数据添加了随机数，导致解码失败。所以但是使用的picture部分没有添加随机数，所以把这部分数据分离出来解码。
2 manhuagui的webp->jpeg图片转换处理，偶尔会出现失败，但是重试后就可以正常处理。所以添加重试处理。